### PR TITLE
Add generateSecureRandomAsBase64

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,14 @@ import { toByteArray } from 'base64-js';
 
 const { RNSecureRandom } = NativeModules;
 
-export function generateSecureRandom(length) {
+export function generateSecureRandomAsBase64(length) {
     if (!RNSecureRandom || !RNSecureRandom.generateSecureRandomAsBase64) {
         return Promise.reject(Error('react-native-securerandom is not properly linked'));
     }
 
-    return RNSecureRandom.generateSecureRandomAsBase64(length).then(base64 => toByteArray(base64));
+    return RNSecureRandom.generateSecureRandomAsBase64(length);
+}
+
+export function generateSecureRandom(length) {
+    return generateSecureRandomAsBase64(length).then(base64 => toByteArray(base64));
 }


### PR DESCRIPTION
I have a use case where I need to transport the random number back to native via the bridge again, thus forcing base64 -> ByteArray through the JS function just adds unnecessary conversions as I need to go back base64 again.

Perhaps it makes sense to be able to retrieve the random number as base64 as well.

Best
Hampus