### PR TITLE
fix: warning api 'variant.getJavaCompile()' is obsolete

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -107,8 +107,8 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task "jar${name}"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        task "jar${name}"(type: Jar, dependsOn: variant.javaCompileProvider) {
+            from variant.javaCompileProvider.get().destinationDir
         }
     }
 


### PR DESCRIPTION
Fixes #17.