### PR TITLE
Fix crash in react native 0.82

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
         repositories {
             google()
             mavenCentral()
-            jcenter()
         }
 
         dependencies {
@@ -56,7 +55,6 @@ repositories {
                 excludeGroup "com.facebook.react"
             }
         }
-    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
This library no longer works in react native 0.82 (and possibly some earlier versions as well) because the jcenter repo shorthand was removed in gradle 8.0. jcenter is not used by this project anyway so I simply removed it